### PR TITLE
Allow setuptools scm customization

### DIFF
--- a/build.py
+++ b/build.py
@@ -8,7 +8,7 @@ name = "pybuilder-scm-ver-plugin"
 authors = [Author("Kyrylo Shpytsya", "kshpitsa@gmail.com")]
 license = "MIT"
 summary = "pybuilder plugin to set project from SCM"
-version = "0.1.1"
+version = "0.2.0"
 url = "https://github.com/kshpytsya/pybuilder-scm-ver-plugin"
 default_task = "publish"
 

--- a/src/main/python/pybuilder_scm_ver_plugin/__init__.py
+++ b/src/main/python/pybuilder_scm_ver_plugin/__init__.py
@@ -1,8 +1,17 @@
-from pybuilder.core import init
+from pybuilder.core import init, task
 import setuptools_scm
 
 
 @init
-def initialize_my_plugin(project):
-    project.version = setuptools_scm.get_version()
+def initialize_my_plugin(project, logger):
+    project.version = "<TO BE EXTRACTED FROM SCM>"
     project.set_property("version", project.version)
+
+@task
+def prepare(project, logger):
+    root = project.get_property("scm_ver_root", ".")
+    relative_to = project.get_property("scm_ver_relative_to", None)
+    logger.debug(f"pybuilder_scm_ver: root: {root}, relative to {relative_to}")
+    project.version = setuptools_scm.get_version(root=root, relative_to=relative_to)
+    project.set_property("version", project.version)
+    logger.info(f"Version extracted from SCM: {project.version}")


### PR DESCRIPTION
This update will allow setuptools_scm customization: 

- `root` via project property `scm_ver_root`
- `relative_to` via project property `scm_ver_relative_to`
- and possibly others in the future...

It turns the initializer into a task (called prepare) so that the project properties set in users' initializers can be used. Not a great deal but I don't see any other option how to solve that.