### PR TITLE
Fix default arguments for setuptools_scm

### DIFF
--- a/build.py
+++ b/build.py
@@ -15,7 +15,7 @@ default_task = "publish"
 
 @init
 def set_properties(project):
-    project.depends_on("setuptools_scm")
+    project.depends_on("setuptools_scm<9.0")
     project.set_property("distutils_classifiers", [
         'Development Status :: 4 - Beta',
         'Programming Language :: Python',

--- a/build.py
+++ b/build.py
@@ -8,7 +8,7 @@ name = "pybuilder-scm-ver-plugin"
 authors = [Author("Kyrylo Shpytsya", "kshpitsa@gmail.com")]
 license = "MIT"
 summary = "pybuilder plugin to set project from SCM"
-version = "0.2.1"
+version = "0.2.2"
 url = "https://github.com/kshpytsya/pybuilder-scm-ver-plugin"
 default_task = "publish"
 


### PR DESCRIPTION
Recent 8.0.x release of pypa/setuptools_scm broke builds that use pybuilder-scm-ver-plugin. 
The maintainer in  pypa/setuptools_scm#930 recommends not passing any defaults to setuptools_scm.get_version(). This PR reflects the recommendation.
This PR also adds version limit setuptools_scm<9.0 to limit future incompatibility.